### PR TITLE
fix: amount of limit on init and constructor for both contracts and products

### DIFF
--- a/src/app/components/contracts/contracts.component.ts
+++ b/src/app/components/contracts/contracts.component.ts
@@ -26,7 +26,6 @@ export class ContractsComponent implements OnInit {
   contracts: any;
   multiInputContracts: any;
   selected: Contract[] = [];
-  filteredDataSource: Contract[];
   subscription: Subscription;
   columnHeaders: string [] = [];
   contractPage: {title: string, description: string} = {title: '', description: ''};
@@ -41,9 +40,6 @@ export class ContractsComponent implements OnInit {
   loading = false;
 
     @ViewChild('table', {static: false}) table: CdkTable<{}[]>;
-
-    dataSource: Contract[];
-
     
     constructor(
       private authService: AuthService,
@@ -60,11 +56,11 @@ export class ContractsComponent implements OnInit {
         this.loading = true;
         this.isLoggedIn = this.authService.isLoggedIn;
         this.subscription = this.contractService.getContractsObservable().subscribe(data => {
+          console.log(data);
           this.lastInArray = data[(data.length - 1)].company;
           this.firstInArray = data[0].company;
           const databaseData = Object.keys(data).map(i => data[i]);
           this.contracts = databaseData;
-          this.dataSource = databaseData;
       });
 
         this.contractService.totalQueryContract.subscribe(data => {this.totalContracts = data.size; });
@@ -95,7 +91,6 @@ export class ContractsComponent implements OnInit {
   refresh() {
       if (this.selected.length === 0) {
           this.currentPage = 1;
-          this.filteredDataSource = this.dataSource;
           this.searching = false;
           } else {
             this.searching = true;
@@ -255,8 +250,6 @@ export class ContractsComponent implements OnInit {
           this.firstInArray = data[0].company;
           const databaseData = Object.keys(data).map(i => data[i]);
           this.contracts = databaseData;
-          this.dataSource = databaseData;
-          this.contracts = databaseData;
         });
       } else if (operator === 'minus') {
         this.currentPage = this.currentPage - 1;
@@ -267,8 +260,7 @@ export class ContractsComponent implements OnInit {
           this.firstInArray = data[0].company;
           const databaseData = Object.keys(data).map(i => data[i]);
           this.contracts = databaseData;
-          this.dataSource = databaseData;
-          this.contracts = databaseData;
+
         });
       }
     }

--- a/src/app/components/products/products.component.ts
+++ b/src/app/components/products/products.component.ts
@@ -79,7 +79,7 @@ export class ProductsComponent implements OnDestroy, OnInit {
                   type: 'success'
                 });
               notif.afterClosed.subscribe( result => {
-                  this.productService.addProduct(this.product, this.totalProducts);
+                  this.productService.addProduct(this.product);
                 });
             }
           } else {
@@ -144,7 +144,7 @@ export class ProductsComponent implements OnDestroy, OnInit {
               if (this.loggedIn) {
                 this.dialogService.open(ConfirmModalComponent).afterClosed.subscribe(result => {
                   if (result) {
-                    this.productService.deleteProduct(name, this.totalProducts);
+                    this.productService.deleteProduct(name);
                   }
                 });
               } else {

--- a/src/app/services/contracts/contracts.service.ts
+++ b/src/app/services/contracts/contracts.service.ts
@@ -15,7 +15,7 @@ export class ContractsService {
 
   constructor(private db: AngularFirestore, private _contractPageService: ContractPageService) {
     this.contractObservable = db.collection('main').doc('en').collection('contracts',
-    ref => ref.orderBy('company', 'asc').limit(1)).valueChanges();
+    ref => ref.orderBy('company', 'asc').limit(5)).valueChanges();
 
     let query = db.collection('main').doc('en').collection('contracts',
     ref => ref.orderBy('company', 'asc'));

--- a/src/app/services/products/products.service.ts
+++ b/src/app/services/products/products.service.ts
@@ -13,7 +13,7 @@ export class ProductsService {
 
   constructor(private db: AngularFirestore, private _productPageService: ProductPageService) {
     this._products = db.collection('main').doc('en').collection('products',
-    ref => ref.orderBy('name', 'asc').limit(1)).valueChanges();
+    ref => ref.orderBy('name', 'asc').limit(5)).valueChanges();
 
     let query = db.collection('main').doc('en').collection('products',
     ref => ref.orderBy('name', 'asc'));
@@ -24,7 +24,7 @@ export class ProductsService {
     return this._products;
   }
 
-  addProduct(product: Product, numOfProducts:number) {
+  addProduct(product: Product) {
     const name = product.name;
     const contact = product.contact;
     const status = product.status;
@@ -46,7 +46,7 @@ export class ProductsService {
     productCollection.update(Object.assign({}, obj));
   }
 
-  deleteProduct(productName, numOfProduct:number) {
+  deleteProduct(productName) {
     this.db.collection('main').doc('en').collection('products').doc(productName).delete();
   }
 


### PR DESCRIPTION
This changes the limit on initialization from 1 per page to 5 per page for the constructor in the services